### PR TITLE
Add file header snippet with support for several languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,33 +31,6 @@
   "activationEvents": [
     "onStartupFinished"
   ],
-  "scripts": {
-    "build": "tsup src/index.ts --external vscode",
-    "dev": "nr build --watch",
-    "lint": "eslint .",
-    "vscode:prepublish": "nr build",
-    "publish": "vsce publish --no-dependencies",
-    "pack": "vsce package --no-dependencies",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit",
-    "release": "bumpp && nr publish"
-  },
-  "devDependencies": {
-    "@antfu/eslint-config": "^0.25.2",
-    "@antfu/ni": "^0.17.2",
-    "@types/node": "^18.6.4",
-    "@types/vscode": "^1.69.0",
-    "bumpp": "^8.2.1",
-    "eslint": "^8.21.0",
-    "esno": "^0.16.3",
-    "pnpm": "^7.8.0",
-    "rimraf": "^3.0.2",
-    "tsup": "^6.2.1",
-    "typescript": "^4.7.4",
-    "vite": "^3.0.4",
-    "vitest": "^0.21.0",
-    "vsce": "^2.10.0"
-  },
   "contributes": {
     "snippets": [
       {
@@ -93,5 +66,32 @@
         "path": "./snippets/snippets.json"
       }
     ]
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --external vscode",
+    "dev": "nr build --watch",
+    "lint": "eslint .",
+    "vscode:prepublish": "nr build",
+    "publish": "vsce publish --no-dependencies",
+    "pack": "vsce package --no-dependencies",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "release": "bumpp && nr publish"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "^0.25.2",
+    "@antfu/ni": "^0.17.2",
+    "@types/node": "^18.6.4",
+    "@types/vscode": "^1.69.0",
+    "bumpp": "^8.2.1",
+    "eslint": "^8.21.0",
+    "esno": "^0.16.3",
+    "pnpm": "^7.8.0",
+    "rimraf": "^3.0.2",
+    "tsup": "^6.2.1",
+    "typescript": "^4.7.4",
+    "vite": "^3.0.4",
+    "vitest": "^0.21.0",
+    "vsce": "^2.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/Seneca-CDOT/vscode-seneca-college/issues"
   },
   "categories": [
+    "Snippets",
     "Other"
   ],
   "main": "./dist/index.js",
@@ -56,5 +57,41 @@
     "vite": "^3.0.4",
     "vitest": "^0.21.0",
     "vsce": "^2.10.0"
+  },
+  "contributes": {
+    "snippets": [
+      {
+        "language": "javascript",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "typescript",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "c++",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "c#",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "java",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "sql",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "html",
+        "path": "./snippets/snippets.json"
+      },
+      {
+        "language": "css",
+        "path": "./snippets/snippets.json"
+      }
+    ]
   }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -6,7 +6,7 @@
       "$LINE_COMMENT Created on: $CURRENT_MONTH_NAME $CURRENT_DATE $CURRENT_YEAR",
       "$LINE_COMMENT Student name: ${1:fullname}",
       "$LINE_COMMENT Student email: ${2:email}@myseneca.ca",
-      "$LINE_COMMENT Class: ${3:classname}",
+      "$LINE_COMMENT Course: ${3:coursename}",
       "$LINE_COMMENT Section: ${4:section}"
     ],
     "description": "Place file header with student info"

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,0 +1,14 @@
+{
+  "Student File Header Template": {
+		"prefix": "!fhead",
+		"body": [
+			"$LINE_COMMENT $RELATIVE_FILEPATH",
+			"$LINE_COMMENT Created on: $CURRENT_MONTH_NAME $CURRENT_DATE $CURRENT_YEAR",
+			"$LINE_COMMENT Student name: ${1:fullname}",
+			"$LINE_COMMENT Student email: ${2:email}@myseneca.ca",
+			"$LINE_COMMENT Class: ${3:classname}",
+			"$LINE_COMMENT Section: ${4:section}"
+		],
+		"description": "Place file header with student info"
+	}
+}

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,14 +1,14 @@
 {
   "Student File Header Template": {
-		"prefix": "!fhead",
-		"body": [
-			"$LINE_COMMENT $RELATIVE_FILEPATH",
-			"$LINE_COMMENT Created on: $CURRENT_MONTH_NAME $CURRENT_DATE $CURRENT_YEAR",
-			"$LINE_COMMENT Student name: ${1:fullname}",
-			"$LINE_COMMENT Student email: ${2:email}@myseneca.ca",
-			"$LINE_COMMENT Class: ${3:classname}",
-			"$LINE_COMMENT Section: ${4:section}"
-		],
-		"description": "Place file header with student info"
-	}
+    "prefix": "!fhead",
+    "body": [
+      "$LINE_COMMENT $RELATIVE_FILEPATH",
+      "$LINE_COMMENT Created on: $CURRENT_MONTH_NAME $CURRENT_DATE $CURRENT_YEAR",
+      "$LINE_COMMENT Student name: ${1:fullname}",
+      "$LINE_COMMENT Student email: ${2:email}@myseneca.ca",
+      "$LINE_COMMENT Class: ${3:classname}",
+      "$LINE_COMMENT Section: ${4:section}"
+    ],
+    "description": "Place file header with student info"
+  }
 }


### PR DESCRIPTION
# Description

Add a snippet for creating the header for files with information about the student and the file itself (create date, path) 

Fixes #5 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

I tested it manually way just by copying the project's directory and pasting it to the extensions folder in `~/.vscode/extensions` and reloading vs code after that. The newly created snippet `!fhead` should become available for you (refer to `package.json` for supported languages)
